### PR TITLE
Fix documentation for resolve() and one PII

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var metaELS = require('meta-els');
 var options = {};
 
 // request for one pii
-metaELS.resolve("S1534580715000751", options, function (err, item) {
+metaELS.resolve({ "pii": "S1534580715000751" }, function (err, item) {
   if (err) { console.error(err); }
   console.log(item);
 });


### PR DESCRIPTION
I did not succeed in resolving several PIIs using:

``` javascript
metaELS.resolve({"piis":["S1534580715000751"]}, function (err, item) {
  console.log("err",err);
  console.log("item",item); 
});
```

I got:

```
err { [Error: Unexpected status code : 401]
  url: 'http://api.elsevier.com/content/search/scidir-object?suppressNavLinks=true&&apiKey=myAPIKeyRequestedOnElsevierSite&httpAccept=application/json&field=url,identifier,description,prism:doi,prism:aggregationType,prism:publicationName,prism:coverDate,prism:pii,eid&count=200&query=pii(S1534580715000751)' }
item undefined
```
